### PR TITLE
Use a one second timeout when checking for version

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -250,6 +250,11 @@ func Check(p *CheckParams) (*CheckResponse, error) {
 	req.Header.Add("User-Agent", "HashiCorp/go-checkpoint")
 
 	client := cleanhttp.DefaultClient()
+
+	// We use a short timeout since checking for new versions is not critical
+	// enough to block on if checkpoint is broken/slow.
+	client.Timeout = time.Duration(1 * time.Second)
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Checking versions is a "nice to have" sort of thing, so we don't want to block progress elsewhere when the checkpoint API is unreachable for any reason.

This leads to an error being returned if the timeout is hit. Our callers that use this API to check for new versions just write errors to the log and continue, so this causes the version check to effectively be ignored when the checkpoint API is down.