### PR TITLE
 Add support for the new version constraints endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/hashicorp/go-checkpoint
+
+require (
+	github.com/hashicorp/go-cleanhttp v0.5.0
+	github.com/hashicorp/go-uuid v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
+github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
+github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,0 +1,118 @@
+package checkpoint
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+	uuid "github.com/hashicorp/go-uuid"
+)
+
+// ReportParams are the parameters for configuring a telemetry report.
+type ReportParams struct {
+	// Signature is some random signature that should be stored and used
+	// as a cookie-like value. This ensures that alerts aren't repeated.
+	// If the signature is changed, repeat alerts may be sent down. The
+	// signature should NOT be anything identifiable to a user (such as
+	// a MAC address). It should be random.
+	//
+	// If SignatureFile is given, then the signature will be read from this
+	// file. If the file doesn't exist, then a random signature will
+	// automatically be generated and stored here. SignatureFile will be
+	// ignored if Signature is given.
+	Signature     string `json:"signature"`
+	SignatureFile string `json:"-"`
+
+	StartTime     time.Time   `json:"start_time"`
+	EndTime       time.Time   `json:"end_time"`
+	Arch          string      `json:"arch"`
+	OS            string      `json:"os"`
+	Payload       interface{} `json:"payload,omitempty"`
+	Product       string      `json:"product"`
+	RunID         string      `json:"run_id"`
+	SchemaVersion string      `json:"schema_version"`
+	Version       string      `json:"version"`
+}
+
+func (i *ReportParams) signature() string {
+	signature := i.Signature
+	if i.Signature == "" && i.SignatureFile != "" {
+		var err error
+		signature, err = checkSignature(i.SignatureFile)
+		if err != nil {
+			return ""
+		}
+	}
+	return signature
+}
+
+// Report sends telemetry information to checkpoint
+func Report(ctx context.Context, r *ReportParams) error {
+	if disabled := os.Getenv("CHECKPOINT_DISABLE"); disabled != "" {
+		return nil
+	}
+
+	req, err := ReportRequest(r)
+	if err != nil {
+		return err
+	}
+
+	client := cleanhttp.DefaultClient()
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 201 {
+		return fmt.Errorf("Unknown status: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// ReportRequest creates a request object for making a report
+func ReportRequest(r *ReportParams) (*http.Request, error) {
+	// Populate some fields automatically if we can
+	if r.RunID == "" {
+		uuid, err := uuid.GenerateUUID()
+		if err != nil {
+			return nil, err
+		}
+		r.RunID = uuid
+	}
+	if r.Arch == "" {
+		r.Arch = runtime.GOARCH
+	}
+	if r.OS == "" {
+		r.OS = runtime.GOOS
+	}
+	if r.Signature == "" {
+		r.Signature = r.signature()
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+
+	u := &url.URL{
+		Scheme: "https",
+		Host:   "checkpoint-api.hashicorp.com",
+		Path:   fmt.Sprintf("/v1/telemetry/%s", r.Product),
+	}
+
+	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "HashiCorp/go-checkpoint")
+
+	return req, nil
+}

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -1,0 +1,33 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestReport_sendsRequest(t *testing.T) {
+	expected := &ReportParams{
+		Signature: "sig",
+		Product:   "prod",
+	}
+
+	req, err := ReportRequest(expected)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer req.Body.Close()
+
+	if !strings.HasSuffix(req.URL.Path, "/telemetry/prod") {
+		t.Fatalf("expected url to include the product, got %s", req.URL.String())
+	}
+
+	var actual ReportParams
+	if err := json.NewDecoder(req.Body).Decode(&actual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if actual.Signature != expected.Signature {
+		t.Fatalf("expected %#v, got %#v", expected, actual)
+	}
+}

--- a/versions.go
+++ b/versions.go
@@ -1,0 +1,90 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// VersionsParams are the parameters for a versions request.
+type VersionsParams struct {
+	// Service is used to lookup the correct service.
+	Service string
+
+	// Product is used to filter the version contraints.
+	Product string
+
+	// Force, if true, will force the check even if CHECKPOINT_DISABLE
+	// is set. Within HashiCorp products, this is ONLY USED when the user
+	// specifically requests it. This is never automatically done without
+	// the user's consent.
+	Force bool
+}
+
+// VersionsResponse is the response for a versions request.
+type VersionsResponse struct {
+	Service   string   `json:"service"`
+	Product   string   `json:"product"`
+	Minimum   string   `json:"minimum"`
+	Maximum   string   `json:"maximum"`
+	Excluding []string `json:"excluding"`
+}
+
+// Versions returns the version constrains for a given service and product.
+func Versions(p *VersionsParams) (*VersionsResponse, error) {
+	if disabled := os.Getenv("CHECKPOINT_DISABLE"); disabled != "" && !p.Force {
+		return &VersionsResponse{}, nil
+	}
+
+	// Set a default timeout of 1 sec for the versions request (in milliseconds)
+	timeout := 1000
+	if _, err := strconv.Atoi(os.Getenv("CHECKPOINT_TIMEOUT")); err == nil {
+		timeout, _ = strconv.Atoi(os.Getenv("CHECKPOINT_TIMEOUT"))
+	}
+
+	v := url.Values{}
+	v.Set("product", p.Product)
+
+	u := &url.URL{
+		Scheme:   "https",
+		Host:     "checkpoint-api.hashicorp.com",
+		Path:     fmt.Sprintf("/v1/versions/%s", p.Service),
+		RawQuery: v.Encode(),
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "HashiCorp/go-checkpoint")
+
+	client := cleanhttp.DefaultClient()
+
+	// We use a short timeout since checking for new versions is not critical
+	// enough to block on if checkpoint is broken/slow.
+	client.Timeout = time.Duration(timeout) * time.Millisecond
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Unknown status: %d", resp.StatusCode)
+	}
+
+	result := &VersionsResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/versions_test.go
+++ b/versions_test.go
@@ -1,0 +1,71 @@
+package checkpoint
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestVersions(t *testing.T) {
+	t.Skip("endpoint does not exist yet")
+
+	expected := &VersionsResponse{
+		Service:   "test.v1",
+		Product:   "test",
+		Minimum:   "1.0",
+		Excluding: []string{"1.3"},
+		Maximum:   "2.0",
+	}
+
+	actual, err := Versions(&VersionsParams{
+		Service: "test.v1",
+		Product: "test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %#v, got: %#v", expected, actual)
+	}
+}
+
+func TestVersions_timeout(t *testing.T) {
+	t.Skip("endpoint does not exist yet")
+
+	os.Setenv("CHECKPOINT_TIMEOUT", "50")
+	defer os.Setenv("CHECKPOINT_TIMEOUT", "")
+
+	expected := "Client.Timeout exceeded while awaiting headers"
+
+	_, err := Versions(&VersionsParams{
+		Service: "test.v1",
+		Product: "test",
+	})
+
+	if err == nil || !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected a timeout error, got: %v", err)
+	}
+}
+
+func TestVersions_disabled(t *testing.T) {
+	t.Skip("endpoint does not exist yet")
+
+	os.Setenv("CHECKPOINT_DISABLE", "1")
+	defer os.Setenv("CHECKPOINT_DISABLE", "")
+
+	expected := &CheckResponse{}
+
+	actual, err := Versions(&VersionsParams{
+		Service: "test.v1",
+		Product: "test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %#v, got: %#v", expected, actual)
+	}
+}


### PR DESCRIPTION
This PR adds support for Go modules and refactored to code a little to make it a bit easier to read.

But the main reason for this PR is adding the client side changes needed to support the new version constraints endpoints added to CheckPoint by the following PRs:

- https://github.com/hashicorp/checkpoint/pull/9
- https://github.com/hashicorp/checkpoint/pull/10